### PR TITLE
fix/layout

### DIFF
--- a/src/layout/layoutBase.jsx
+++ b/src/layout/layoutBase.jsx
@@ -7,7 +7,7 @@ import BreadcrumbsNav from '../components/common/BreadcrumbsNav';
 export default function LayoutBase() {
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
-      <Container maxWidth="lg" sx={{ mt: 4, flexGrow: 1 }}>
+      <Container maxWidth="lg" sx={{ mt: { xs: 11, md: 4 }, flexGrow: 1 }}>
         <BreadcrumbsNav />
         <Sidebar />
         <Box component="main" sx={{ flexGrow: 1, mt: 3 }}>


### PR DESCRIPTION
# layoutBase

## Descripción
Se ajusta el layout en pantalla móvil para evitar superposición con la sidebar. 

## Problema
<img width="317" height="823" alt="image" src="https://github.com/user-attachments/assets/5a7d416c-080f-4007-bb7d-437c8d376fa0" />

## Fix
<img width="317" height="831" alt="image" src="https://github.com/user-attachments/assets/b8f0898a-b218-4b38-8a83-c73c020974d0" />
