### PR TITLE
Refactor agenda de turnos

### DIFF
--- a/src/components/agenda-turnos/AltaTurnosForm.jsx
+++ b/src/components/agenda-turnos/AltaTurnosForm.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { Box, Divider } from '@mui/material';
 import PrestadorSection from './PrestadorSection';
 import HorariosSection from './HorariosSection';
@@ -29,6 +29,7 @@ export default function AltaTurnosForm() {
     prestador,
     especialidadSeleccionada,
   } = usePrestador();
+
   const {
     horarios,
     listVersion,
@@ -39,9 +40,20 @@ export default function AltaTurnosForm() {
 
   const [saving, setSaving] = useState(false);
   const [showError, setShowError] = useState(false);
+
   const { validateBeforeSave } = useFormValidation(validateAltaTurnos);
 
-  const handleGuardar = () => {
+  const handleChangeHorario = useCallback(
+    (id, newHorario) => actualizarHorario(id, newHorario),
+    [actualizarHorario]
+  );
+
+  const handleEliminarHorario = useCallback(
+    (id) => eliminarHorario(id),
+    [eliminarHorario]
+  );
+
+  const handleGuardar = useCallback(() => {
     validateBeforeSave(
       {
         prestador,
@@ -68,9 +80,19 @@ export default function AltaTurnosForm() {
         }
       }
     );
-  };
+  }, [
+    validateBeforeSave,
+    prestador,
+    especialidadSeleccionada,
+    direccionSeleccionada,
+    horarios,
+    navigateToEdicion,
+  ]);
 
-  const handleCancelar = () => navigateToListado('alta-cancelada');
+  const handleCancelar = useCallback(
+    () => navigateToListado('alta-cancelada'),
+    [navigateToListado]
+  );
 
   return (
     <Box component="form" noValidate>
@@ -79,17 +101,18 @@ export default function AltaTurnosForm() {
       <PrestadorSection />
       <Divider sx={{ mt: 4 }} />
 
-      <div key={`horarios-group-${listVersion}`}>
-        <AnimatePresence>
+      {/* Horarios */}
+      <AnimatePresence>
+        <div key={`horarios-group-${listVersion}`}>
           {horarios.map((horario, index) => (
             <FadeSlide key={horario.id}>
               <HorariosSection
                 horario={horario}
                 numero={index + 1}
                 puedeEliminar={horarios.length > 1}
-                onEliminar={() => eliminarHorario(horario.id)}
+                onEliminar={() => handleEliminarHorario(horario.id)}
                 onChange={(newHorario) =>
-                  actualizarHorario(horario.id, newHorario)
+                  handleChangeHorario(horario.id, newHorario)
                 }
               />
 
@@ -101,17 +124,19 @@ export default function AltaTurnosForm() {
               )}
             </FadeSlide>
           ))}
-        </AnimatePresence>
-      </div>
+        </div>
+      </AnimatePresence>
 
       <Divider sx={{ my: 4 }} />
 
+      {/* Botones de acción */}
       <ButtonsSection
         handleGuardar={handleGuardar}
         onConfirmCancel={handleCancelar}
         cancelTitle="¿Cancelar alta de agenda de turnos?"
         cancelMessage="Si cancelás ahora, se perderán todos los cambios que hayas hecho en el formulario."
       />
+
       <ErrorSnackbar
         open={showError}
         onClose={() => setShowError(false)}

--- a/src/components/agenda-turnos/AltaTurnosForm.jsx
+++ b/src/components/agenda-turnos/AltaTurnosForm.jsx
@@ -30,13 +30,8 @@ export default function AltaTurnosForm() {
     especialidadSeleccionada,
   } = usePrestador();
 
-  const {
-    horarios,
-    listVersion,
-    agregarHorario,
-    eliminarHorario,
-    actualizarHorario,
-  } = useHorarios();
+  const { horarios, agregarHorario, eliminarHorario, actualizarHorario } =
+    useHorarios();
 
   const [saving, setSaving] = useState(false);
   const [showError, setShowError] = useState(false);
@@ -103,7 +98,7 @@ export default function AltaTurnosForm() {
 
       {/* Horarios */}
       <AnimatePresence>
-        <div key={`horarios-group-${listVersion}`}>
+        <div>
           {horarios.map((horario, index) => (
             <FadeSlide key={horario.id}>
               <HorariosSection

--- a/src/components/agenda-turnos/HorariosSection.jsx
+++ b/src/components/agenda-turnos/HorariosSection.jsx
@@ -17,23 +17,40 @@ export default function HorariosSection({
   const { direccionSeleccionada } = usePrestador();
   const { error, clearError } = useFormValidationContext();
 
-  const horarios = direccionSeleccionada?.horarios || [];
-  const diasSemana = [...new Set(horarios.map((h) => h.dia.nombre))];
+  const horarios = React.useMemo(
+    () => direccionSeleccionada?.horarios || [],
+    [direccionSeleccionada]
+  );
 
-  const diasConHorarios = diasSemana.map((dia) => {
-    const rangos = horarios
-      .filter((h) => h.dia.nombre === dia)
-      .map((h) => `${h.horaInicio} - ${h.horaFin}`)
-      .join(', ');
-    return rangos ? `${dia} (${rangos})` : dia;
-  });
+  const diasSemana = React.useMemo(
+    () => [...new Set(horarios.map((h) => h.dia.nombre))],
+    [horarios]
+  );
 
-  const duraciones = Array.from({ length: 24 }, (_, i) => (i + 1) * 5);
+  const diasConHorarios = React.useMemo(
+    () =>
+      diasSemana.map((dia) => {
+        const rangos = horarios
+          .filter((h) => h.dia.nombre === dia)
+          .map((h) => `${h.horaInicio} - ${h.horaFin}`)
+          .join(', ');
+        return rangos ? `${dia} (${rangos})` : dia;
+      }),
+    [diasSemana, horarios]
+  );
 
-  const handleFieldChange = (field, value) => {
-    onChange({ ...horario, [field]: value });
-    if (value) clearError(`horario-${horario.id}-${field}`);
-  };
+  const duraciones = React.useMemo(
+    () => Array.from({ length: 24 }, (_, i) => (i + 1) * 5),
+    []
+  );
+
+  const handleFieldChange = React.useCallback(
+    (field, value) => {
+      onChange({ ...horario, [field]: value });
+      if (value) clearError(`horario-${horario.id}-${field}`);
+    },
+    [onChange, horario, clearError]
+  );
 
   return (
     <Box sx={{ mt: 4 }}>

--- a/src/components/agenda-turnos/HorariosSection.jsx
+++ b/src/components/agenda-turnos/HorariosSection.jsx
@@ -17,12 +17,19 @@ export default function HorariosSection({
   const { direccionSeleccionada } = usePrestador();
   const { error, clearError } = useFormValidationContext();
 
-  const diasSemana =
-    direccionSeleccionada?.horarios?.map((h) => h.dia.nombre) || [];
+  const horarios = direccionSeleccionada?.horarios || [];
+  const diasSemana = [...new Set(horarios.map((h) => h.dia.nombre))];
+
+  const diasConHorarios = diasSemana.map((dia) => {
+    const rangos = horarios
+      .filter((h) => h.dia.nombre === dia)
+      .map((h) => `${h.horaInicio} - ${h.horaFin}`)
+      .join(', ');
+    return rangos ? `${dia} (${rangos})` : dia;
+  });
 
   const duraciones = Array.from({ length: 24 }, (_, i) => (i + 1) * 5);
 
-  // Handler genérico
   const handleFieldChange = (field, value) => {
     onChange({ ...horario, [field]: value });
     if (value) clearError(`horario-${horario.id}-${field}`);
@@ -45,8 +52,9 @@ export default function HorariosSection({
             <Typography variant="subtitle1" fontWeight="medium">
               Días de la semana
             </Typography>
+
             <DiasSemanaSelector
-              dias={diasSemana}
+              dias={diasConHorarios}
               selected={horario.dias}
               onChange={(newDias) => handleFieldChange('dias', newDias)}
               dataField={`horario-${horario.id}-dias`}
@@ -62,6 +70,7 @@ export default function HorariosSection({
             <Typography variant="subtitle1" fontWeight="medium" sx={{ mt: 3 }}>
               Especificaciones del turno
             </Typography>
+
             <Grid container spacing={3} sx={{ mt: 3 }}>
               <Grid size={{ xs: 12, sm: 6, md: 4 }}>
                 <Autocomplete
@@ -91,36 +100,15 @@ export default function HorariosSection({
 
               <HorarioPickerGroup
                 horario={horario}
-                onChange={(field, value) => handleFieldChange(field, value)}
-                dataFieldGroup={`horario-${horario.id}-horario`}
-                dataFieldInicio={`horario-${horario.id}-inicio`}
-                dataFieldFin={`horario-${horario.id}-fin`}
-                errorInicio={error?.field === `horario-${horario.id}-inicio`}
-                helperTextInicio={
-                  error?.field === `horario-${horario.id}-inicio`
-                    ? error?.message
-                    : ''
-                }
-                errorFin={error?.field === `horario-${horario.id}-fin`}
-                helperTextFin={
-                  error?.field === `horario-${horario.id}-fin`
-                    ? error?.message
-                    : ''
-                }
-                groupError={error?.field === `horario-${horario.id}-horario`}
-                groupHelperText={
-                  error?.field === `horario-${horario.id}-horario`
-                    ? error?.message
-                    : ''
-                }
+                onChange={handleFieldChange}
+                idPrefix={`horario-${horario.id}`}
               />
             </Grid>
 
-            {/* Botón de eliminar */}
             {puedeEliminar && (
               <EliminarButton
                 onEliminar={onEliminar}
-                label={'Eliminar horario'}
+                label="Eliminar horario"
               />
             )}
           </>
@@ -137,7 +125,7 @@ HorariosSection.propTypes = {
     inicio: PropTypes.object,
     fin: PropTypes.object,
     dias: PropTypes.array,
-  }),
+  }).isRequired,
   puedeEliminar: PropTypes.bool,
   onEliminar: PropTypes.func,
   onChange: PropTypes.func.isRequired,

--- a/src/components/agenda-turnos/PrestadorSection.jsx
+++ b/src/components/agenda-turnos/PrestadorSection.jsx
@@ -9,7 +9,6 @@ export default function PrestadorSection() {
   const {
     prestador,
     prestadores,
-    info,
     seleccionarPrestador,
     especialidadSeleccionada,
     setEspecialidadSeleccionada,
@@ -19,14 +18,13 @@ export default function PrestadorSection() {
 
   const { resetHorarios } = useHorarios();
   const { clearError, clearErrorsByPrefix } = useFormValidationContext();
-
   const especialidadRef = useRef(null);
 
   useLayoutEffect(() => {
-    if (prestador && info.especialidades.length > 0) {
+    if (prestador?.especialidades?.length > 0) {
       especialidadRef.current?.querySelector('input')?.focus();
     }
-  }, [prestador, info.especialidades]);
+  }, [prestador?.especialidades]);
 
   const handleChange = (setter, clearKey) => (_, newValue) => {
     setter(newValue);
@@ -37,7 +35,6 @@ export default function PrestadorSection() {
     resetHorarios();
     clearErrorsByPrefix('horario-');
     clearError('horarios');
-
     setDireccionSeleccionada(newValue);
     if (newValue) clearError('direccion');
   };
@@ -67,7 +64,7 @@ export default function PrestadorSection() {
           <ValidatedAutocomplete
             value={especialidadSeleccionada}
             onChange={handleChange(setEspecialidadSeleccionada, 'especialidad')}
-            options={info.especialidades}
+            options={prestador?.especialidades || []}
             getOptionLabel={(option) => option?.nombre || ''}
             isOptionEqualToValue={(option, value) => option.id === value.id}
             label="Especialidad"
@@ -82,7 +79,7 @@ export default function PrestadorSection() {
           <ValidatedAutocomplete
             value={direccionSeleccionada}
             onChange={handleDireccionChange}
-            options={info.direcciones}
+            options={prestador?.centrosDeAtencion || []}
             getOptionLabel={(option) =>
               option?.calle ? `${option.calle} ${option.altura || ''}` : option
             }

--- a/src/components/common/forms/HorarioPickerGroup.jsx
+++ b/src/components/common/forms/HorarioPickerGroup.jsx
@@ -74,5 +74,5 @@ HorarioPickerGroup.propTypes = {
     fin: PropTypes.object,
   }).isRequired,
   onChange: PropTypes.func.isRequired,
-  idPrefix: PropTypes.string.isRequired, // ejemplo: "horario-<id>"
+  idPrefix: PropTypes.string.isRequired,
 };

--- a/src/components/common/forms/HorarioPickerGroup.jsx
+++ b/src/components/common/forms/HorarioPickerGroup.jsx
@@ -2,76 +2,63 @@ import PropTypes from 'prop-types';
 import { Grid } from '@mui/material';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import { DesktopTimePicker } from '@mui/x-date-pickers/DesktopTimePicker';
+import { MobileTimePicker } from '@mui/x-date-pickers/MobileTimePicker';
 import { useFormValidationContext } from '../../../context/FormValidationContext';
 
-export default function HorarioPickerGroup({
-  horario,
-  onChange,
-  dataFieldInicio,
-  dataFieldFin,
-  dataFieldGroup,
-  errorInicio,
-  helperTextInicio,
-  errorFin,
-  helperTextFin,
-  groupError,
-  groupHelperText,
-}) {
-  const { clearError } = useFormValidationContext();
+export default function HorarioPickerGroup({ horario, onChange, idPrefix }) {
+  const { error, clearError, clearErrorsByPrefix } = useFormValidationContext();
+
+  const isFieldError = (suffix) => error?.field === `${idPrefix}-${suffix}`;
+  const getHelperText = (suffix) =>
+    isFieldError(suffix) ? error?.message : '';
+
+  const isGroupError = error?.field === `${idPrefix}-horario`;
+  const groupHelperText = isGroupError ? error?.message : '';
+
+  const handleChange = (field, value) => {
+    onChange(field, value);
+
+    if (value) {
+      clearError(`${idPrefix}-${field}`);
+      clearErrorsByPrefix(idPrefix);
+    }
+  };
 
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Grid container spacing={3} size={{ xs: 12, sm: 12, md: 8 }}>
-        {/* Horario inicio */}
-        <Grid size={{ xs: 12, sm: 6, md: 6 }}>
-          <DesktopTimePicker
+        {/* Hora de inicio */}
+        <Grid size={{ xs: 12, sm: 6 }}>
+          <MobileTimePicker
             label="Horario inicio"
             value={horario.inicio}
-            onChange={(newValue) => {
-              onChange('inicio', newValue);
-              if (newValue) {
-                clearError(dataFieldInicio);
-                clearError(dataFieldGroup);
-              }
-            }}
+            onChange={(v) => handleChange('inicio', v)}
             slotProps={{
               textField: {
                 fullWidth: true,
-                error: errorInicio || groupError,
-                helperText: errorInicio
-                  ? helperTextInicio
-                  : groupError
-                    ? groupHelperText
-                    : '',
-                'data-field': dataFieldInicio,
+                error: isFieldError('inicio') || isGroupError,
+                helperText:
+                  getHelperText('inicio') ||
+                  (isGroupError ? groupHelperText : ''),
+                'data-field': `${idPrefix}-inicio`,
               },
             }}
           />
         </Grid>
 
-        {/* Horario fin */}
-        <Grid size={{ xs: 12, sm: 6, md: 6 }}>
-          <DesktopTimePicker
+        {/* Hora de fin */}
+        <Grid size={{ xs: 12, sm: 6 }}>
+          <MobileTimePicker
             label="Horario fin"
             value={horario.fin}
-            onChange={(newValue) => {
-              onChange('fin', newValue);
-              if (newValue) {
-                clearError(dataFieldFin);
-                clearError(dataFieldGroup);
-              }
-            }}
+            onChange={(v) => handleChange('fin', v)}
             slotProps={{
               textField: {
                 fullWidth: true,
-                error: errorFin || groupError,
-                helperText: errorFin
-                  ? helperTextFin
-                  : groupError
-                    ? groupHelperText
-                    : '',
-                'data-field': dataFieldFin,
+                error: isFieldError('fin') || isGroupError,
+                helperText:
+                  getHelperText('fin') || (isGroupError ? groupHelperText : ''),
+                'data-field': `${idPrefix}-fin`,
               },
             }}
           />
@@ -87,13 +74,5 @@ HorarioPickerGroup.propTypes = {
     fin: PropTypes.object,
   }).isRequired,
   onChange: PropTypes.func.isRequired,
-  dataFieldInicio: PropTypes.string.isRequired,
-  dataFieldFin: PropTypes.string.isRequired,
-  dataFieldGroup: PropTypes.string.isRequired,
-  errorInicio: PropTypes.bool,
-  helperTextInicio: PropTypes.string,
-  errorFin: PropTypes.bool,
-  helperTextFin: PropTypes.string,
-  groupError: PropTypes.bool,
-  groupHelperText: PropTypes.string,
+  idPrefix: PropTypes.string.isRequired, // ejemplo: "horario-<id>"
 };

--- a/src/components/prestadores/HorarioDeAtencion.jsx
+++ b/src/components/prestadores/HorarioDeAtencion.jsx
@@ -13,62 +13,45 @@ export default function HorarioSection({
   onEliminar,
 }) {
   const { error } = useFormValidationContext();
+  const idPrefix = `horario-${horario.id}`;
+
+  const isError = (suffix) => error?.field === `${idPrefix}-${suffix}`;
+  const getHelper = (suffix) => (isError(suffix) ? error?.message : '');
 
   const handleFieldChange = (field, value) => {
     onChange({ ...horario, [field]: value });
   };
 
   return (
-    <Box sx={{ p: 2, border: '1px solid #ccc', borderRadius: 1, mb: 2 }}>
-      <Grid container spacing={2} alignItems="center">
+    <Box sx={{ p: 2, border: '1px solid #ddd', borderRadius: 2, mb: 3 }}>
+      <Grid container spacing={3}>
         <Grid size={{ xs: 12, sm: 6, md: 12 }}>
           <Typography variant="subtitle2" sx={{ mb: 1 }}>
-            Día de la Semana
+            Días de la semana
           </Typography>
           <DiasSemanaSelector
             dias={DIAS_SEMANA}
             selected={horario.dias}
             onChange={(newDias) => handleFieldChange('dias', newDias)}
-            dataField={`horario-${horario.id}-dias`}
-            error={error?.field === `horario-${horario.id}-dias`}
-            helperText={
-              error?.field === `horario-${horario.id}-dias`
-                ? error?.message
-                : ''
-            }
+            dataField={`${idPrefix}-dias`}
+            error={isError('dias')}
+            helperText={getHelper('dias')}
           />
         </Grid>
 
         <Grid size={{ xs: 12, sm: 6, md: 12 }}>
           <HorarioPickerGroup
             horario={horario}
-            onChange={(field, value) => handleFieldChange(field, value)}
-            dataFieldGroup={`horario-${horario.id}-horario`}
-            dataFieldInicio={`horario-${horario.id}-inicio`}
-            dataFieldFin={`horario-${horario.id}-fin`}
-            errorInicio={error?.field === `horario-${horario.id}-inicio`}
-            helperTextInicio={
-              error?.field === `horario-${horario.id}-inicio`
-                ? error?.message
-                : ''
-            }
-            errorFin={error?.field === `horario-${horario.id}-fin`}
-            helperTextFin={
-              error?.field === `horario-${horario.id}-fin` ? error?.message : ''
-            }
-            groupError={error?.field === `horario-${horario.id}-horario`}
-            groupHelperText={
-              error?.field === `horario-${horario.id}-horario`
-                ? error?.message
-                : ''
-            }
+            onChange={handleFieldChange}
+            idPrefix={idPrefix}
           />
         </Grid>
-        <Grid size={{ xs: 12, sm: 6, md: 12 }}>
-          {puedeEliminar && (
+
+        {puedeEliminar && (
+          <Grid size={{ xs: 12, sm: 6, md: 12 }}>
             <EliminarButton onEliminar={onEliminar} label="Eliminar horario" />
-          )}
-        </Grid>
+          </Grid>
+        )}
       </Grid>
     </Box>
   );
@@ -76,7 +59,6 @@ export default function HorarioSection({
 
 HorarioSection.propTypes = {
   horario: PropTypes.object.isRequired,
-  numero: PropTypes.number.isRequired,
   puedeEliminar: PropTypes.bool,
   onChange: PropTypes.func.isRequired,
   onEliminar: PropTypes.func.isRequired,

--- a/src/context/HorariosContext.jsx
+++ b/src/context/HorariosContext.jsx
@@ -6,7 +6,6 @@ const HorariosContext = createContext();
 
 export function HorariosProvider({ children }) {
   const [horarios, setHorarios] = useState([makeHorario()]);
-  const [listVersion, setListVersion] = useState(0);
 
   const agregarHorario = () => setHorarios((prev) => [...prev, makeHorario()]);
 
@@ -18,14 +17,12 @@ export function HorariosProvider({ children }) {
 
   const resetHorarios = () => {
     setHorarios([makeHorario()]);
-    setListVersion((v) => v + 1);
   };
 
   return (
     <HorariosContext.Provider
       value={{
         horarios,
-        listVersion,
         agregarHorario,
         eliminarHorario,
         actualizarHorario,

--- a/src/context/HorariosContext.jsx
+++ b/src/context/HorariosContext.jsx
@@ -37,6 +37,8 @@ export function HorariosProvider({ children }) {
   );
 }
 
-HorariosProvider.propTypes = { children: PropTypes.node.isRequired };
+HorariosProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};
 
 export const useHorarios = () => useContext(HorariosContext);

--- a/src/context/PrestadorContext.jsx
+++ b/src/context/PrestadorContext.jsx
@@ -12,11 +12,6 @@ export function PrestadorProvider({ children }) {
   const [especialidadSeleccionada, setEspecialidadSeleccionada] =
     useState(null);
   const [direccionSeleccionada, setDireccionSeleccionada] = useState(null);
-  const [info, setInfo] = useState({
-    especialidades: [],
-    direcciones: [],
-    horarios: [],
-  });
 
   useEffect(() => {
     const fetchPrestadores = async () => {
@@ -27,7 +22,6 @@ export function PrestadorProvider({ children }) {
         setPrestadores(data);
       } catch (err) {
         console.error('Error cargando lista de prestadores:', err);
-        setPrestadores([]);
       } finally {
         setLoading(false);
       }
@@ -37,29 +31,21 @@ export function PrestadorProvider({ children }) {
   }, []);
 
   const seleccionarPrestador = async (prestadorObj) => {
-    setPrestador(prestadorObj);
+    setPrestador(null);
     setEspecialidadSeleccionada(null);
     setDireccionSeleccionada(null);
-    setInfo({ especialidades: [], direcciones: [], horarios: [] });
-
     if (!prestadorObj) return;
 
     setLoading(true);
     try {
       await sleepIfLocal(1500);
       const data = await getPrestadorById(prestadorObj.id);
-
-      setInfo({
-        especialidades: data.especialidades || [],
-        direcciones: data.centrosDeAtencion || [],
-        horarios: data.horarios || [],
-      });
+      setPrestador(data);
     } catch (err) {
       console.error(
         `Error cargando info del prestador ${prestadorObj.id}:`,
         err
       );
-      setInfo({ especialidades: [], direcciones: [], horarios: [] });
     } finally {
       setLoading(false);
     }
@@ -70,7 +56,6 @@ export function PrestadorProvider({ children }) {
       value={{
         prestadores,
         prestador,
-        info,
         seleccionarPrestador,
         especialidadSeleccionada,
         setEspecialidadSeleccionada,

--- a/src/utils/horarios.js
+++ b/src/utils/horarios.js
@@ -1,7 +1,11 @@
-export const makeHorario = () => ({
-  id: crypto.randomUUID(),
-  dias: [],
-  duracion: null,
-  inicio: null,
-  fin: null,
-});
+import dayjs from 'dayjs';
+
+export function makeHorario() {
+  return {
+    id: crypto.randomUUID?.(),
+    dias: [],
+    duracion: null,
+    inicio: dayjs().hour(9).minute(0),
+    fin: dayjs().hour(17).minute(0),
+  };
+}

--- a/src/utils/horarios.js
+++ b/src/utils/horarios.js
@@ -6,6 +6,6 @@ export function makeHorario() {
     dias: [],
     duracion: null,
     inicio: dayjs().hour(9).minute(0),
-    fin: dayjs().hour(17).minute(0),
+    fin: dayjs().hour(12).minute(0),
   };
 }

--- a/src/utils/validations/validateHorarios.js
+++ b/src/utils/validations/validateHorarios.js
@@ -1,4 +1,15 @@
-// Validaciones específicas de un horario individual
+import dayjs from 'dayjs';
+import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
+import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
+
+dayjs.extend(isSameOrBefore);
+dayjs.extend(isSameOrAfter);
+
+const normalizarDia = (diaRaw) => {
+  if (typeof diaRaw !== 'string') return '';
+  return diaRaw.split('(')[0].trim();
+};
+
 export const validateHorarioBasico = (horario) => {
   if (!horario.dias || horario.dias.length === 0) {
     return {
@@ -45,18 +56,20 @@ export const validateHorarioBasico = (horario) => {
   return null;
 };
 
-// Validar que esté dentro de los horarios definidos en la dirección
 export const validateHorarioDentroDireccion = (horario, direccion) => {
   const rangoMin = horario.inicio.format('HH:mm');
   const rangoMax = horario.fin.format('HH:mm');
 
-  for (const dia of horario.dias) {
+  for (const diaRaw of horario.dias) {
+    const dia = normalizarDia(diaRaw);
+
     const match = direccion.horarios?.some(
       (dh) =>
         dh.dia.nombre === dia &&
         dh.horaInicio <= rangoMin &&
         dh.horaFin >= rangoMax
     );
+
     if (!match) {
       return {
         field: `horario-${horario.id}-horario`,
@@ -68,7 +81,6 @@ export const validateHorarioDentroDireccion = (horario, direccion) => {
   return null;
 };
 
-// Validar que la duración sea menor o igual al rango
 export const validateDuracionVsRango = (horario) => {
   const rangoMinutos = horario.fin.diff(horario.inicio, 'minute');
   if (horario.duracion > rangoMinutos) {
@@ -80,35 +92,34 @@ export const validateDuracionVsRango = (horario) => {
   return null;
 };
 
-// Validar que no se solape con otro horario
 export const validateSolapamiento = (horario, horarios) => {
   const index = horarios.findIndex((h) => h.id === horario.id);
 
   for (let j = 0; j < index; j++) {
     const other = horarios[j];
-    const overlap = horario.dias.some((d) => other.dias.includes(d));
+    const compartenDia = horario.dias.some((d) =>
+      other.dias.map(normalizarDia).includes(normalizarDia(d))
+    );
 
-    if (overlap) {
-      const startsInside =
-        horario.inicio.isBefore(other.fin) &&
-        (horario.inicio.isSame(other.inicio) ||
-          horario.inicio.isAfter(other.inicio));
+    if (!compartenDia) continue;
 
-      const endsInside =
-        horario.fin.isAfter(other.inicio) &&
-        (horario.fin.isSame(other.fin) || horario.fin.isBefore(other.fin));
+    const empiezaDuranteOtro =
+      horario.inicio.isAfter(other.inicio) &&
+      horario.inicio.isBefore(other.fin);
 
-      const fullyCovers =
-        horario.inicio.isBefore(other.inicio) && horario.fin.isAfter(other.fin);
+    const terminaDuranteOtro =
+      horario.fin.isAfter(other.inicio) && horario.fin.isBefore(other.fin);
 
-      if (startsInside || endsInside || fullyCovers) {
-        return {
-          field: `horario-${horario.id}-horario`,
-          message: `El rango horario se solapa con otro definido para ${horario.dias.join(
-            ', '
-          )}`,
-        };
-      }
+    const cubreTotalmente =
+      horario.inicio.isSameOrBefore(other.inicio) &&
+      horario.fin.isSameOrAfter(other.fin);
+
+    if (empiezaDuranteOtro || terminaDuranteOtro || cubreTotalmente) {
+      const diasLimpios = horario.dias.map(normalizarDia).join(', ');
+      return {
+        field: `horario-${horario.id}-horario`,
+        message: `El rango horario se solapa con otro definido para ${diasLimpios}`,
+      };
     }
   }
 


### PR DESCRIPTION
Realizamos algunos cambios para simplificar la lógica:
1. Mejoramos la performance de funciones recurrentes con useCallback
2. Agregamos el horario a los días a seleccionar en la turnera
3. Evitamos prop drilling derivando cierta lógica de validacones de errores al componente HorarioPickerGroup en lugar de enviarlos por parámetro
4. Simplificamos la lógica del context de prestador
5. Le damos un value por default al horario para que no esté vacío 
6. Mejoramos la lógica de las validaciones de horarios
7. Usamos el selector de horario de mobile