### PR TITLE
fixes para evitar problemas en pantallas que comparten pegadas/componentes

### DIFF
--- a/src/context/PrestadorContext.jsx
+++ b/src/context/PrestadorContext.jsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { getPrestadores, getPrestadorById } from '../services/prestadores';
+import { getPrestadorById, getPrestadores } from '../services/agendaTurnos';
 import { sleepIfLocal } from '../utils/sleepIfLocal';
 
 const PrestadorContext = createContext();

--- a/src/services/agendaTurnos.js
+++ b/src/services/agendaTurnos.js
@@ -69,3 +69,41 @@ export const getAgendaTurnosListado = async (
     throw err;
   }
 };
+
+/**
+ * Obtener los prestadores para agenda de turnos
+ */
+export const getPrestadores = async () => {
+  try {
+    const { data } = await api.get('/agenda-turnos/prestadores');
+    if (!Array.isArray(data)) {
+      throw new Error('Formato inesperado en la respuesta de prestadores');
+    }
+    return data;
+  } catch (err) {
+    console.error('Error al obtener prestadores:', err);
+    throw err;
+  }
+};
+
+/**
+ * Obtener un prestador por ID
+ */
+export const getPrestadorById = async (id) => {
+  if (!id) {
+    throw new Error('Se requiere un ID de prestador');
+  }
+
+  try {
+    const { data } = await api.get(`/prestadores/${id}`);
+    if (!data || typeof data !== 'object') {
+      throw new Error(
+        `Prestador con ID ${id} no encontrado o formato inválido`
+      );
+    }
+    return data;
+  } catch (err) {
+    console.error(`Error al obtener prestador con ID ${id}:`, err);
+    throw err;
+  }
+};

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -62,8 +62,8 @@ api.interceptors.request.use((config) => {
         return Promise.reject({ isMock: true, data });
       }
     }
-    
-    if (config.url.startsWith('/prestadores') && config.method === 'get') {
+
+    if (config.url == '/prestadores' && config.method === 'get') {
       const filters = config.params || {};
       const page = Number(filters.page) || 1;
       const limit = Number(filters.limit) || 10;
@@ -74,8 +74,7 @@ api.interceptors.request.use((config) => {
         const numeros = p.telefonos.map((t) => t.numero);
         const correos = p.emails.map((e) => e.direccion);
         const dirs = p.centrosDeAtencion.map(
-          (d) =>
-           `${d.calle} ${d.altura || ''}, ${d.localidad}, ${d.provincia}`
+          (d) => `${d.calle} ${d.altura || ''}, ${d.localidad}, ${d.provincia}`
         );
 
         return {
@@ -89,16 +88,16 @@ api.interceptors.request.use((config) => {
           emails: correos,
           createdAt: p.createdAt,
         };
-       });
-       return Promise.reject({
-         isMock: true,
-         data: {
-           ...data,
-           items: itemsFormateados,
-         },
-       });
-     }
-    
+      });
+      return Promise.reject({
+        isMock: true,
+        data: {
+          ...data,
+          items: itemsFormateados,
+        },
+      });
+    }
+
     for (const [url, fn] of Object.entries(afiliadosFiltrosMock)) {
       if (config.url.startsWith(url) && config.method === 'get') {
         const search = config.params?.textInputSearch || '';
@@ -107,7 +106,7 @@ api.interceptors.request.use((config) => {
       }
     }
 
-    if (config.url.startsWith('/afiliados') && config.method === 'get') {
+    if (config.url == '/afiliados' && config.method === 'get') {
       const filters = config.params || {};
       const page = Number(filters.page) || 1;
       const limit = Number(filters.limit) || 10;
@@ -145,8 +144,7 @@ api.interceptors.request.use((config) => {
         },
       });
     }
-    
-    
+
     if (
       config.url === '/agenda-turnos' &&
       config.method === 'post' &&
@@ -165,7 +163,7 @@ api.interceptors.request.use((config) => {
       });
     }
 
-    if (config.url === '/prestadores')
+    if (config.url === '/agenda-turnos/prestadores')
       return Promise.reject({ isMock: true, data: prestadoresMock });
 
     if (config.url === '/prestadores/1')

--- a/src/utils/prestadores.js
+++ b/src/utils/prestadores.js
@@ -18,13 +18,14 @@ export const newCentroDeAtencion = () => ({
   horarios: [newHorario()],
 });
 
+//TODO: Dinámico para obtener los ids dinámicos
 export const DIAS_SEMANA = [
-  'Lunes',
-  'Martes',
-  'Miércoles',
-  'Jueves',
-  'Viernes',
-  'Sábado',
+  { id: 1, nombre: 'lunes', label: 'Lunes' },
+  { id: 2, nombre: 'martes', label: 'Martes' },
+  { id: 3, nombre: 'miercoles', label: 'Miércoles' },
+  { id: 4, nombre: 'jueves', label: 'Jueves' },
+  { id: 5, nombre: 'viernes', label: 'Viernes' },
+  { id: 6, nombre: 'sabado', label: 'Sábado' },
 ];
 
 export const diaToBackend = (nombre) => ({


### PR DESCRIPTION
Encontré los siguientes problemas:
1. Endpoints compartidos entre agenda de turnos y prestadores que devuelve info distinta. Cambié las rutas para que cada una devuelva lo que se necesita en la vista adecuada
2. Lógica de mocks que no permitía que se llegue a la ruta desea (evitar uso de funciones ambiguas como "Like")
3. Actualización de alta de prestadores para tener lógica de ID desde el checkbox (Queda pendiente hacerlo dinámico, está hardcoded)
